### PR TITLE
fix parseJSON error handlers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,11 +14,10 @@ let setOptions = (options) => {
 }
 
 let parseJSON = (response) => {
-    try {
-        return response.json()
-    } catch (e) {
-        throw new Error("JSON Parse Error")
-    }
+    return response.json()
+        .catch(err => {
+            throw new Error("JSON Parse Error")
+        })
 }
 
 let checkStatus = (response) => {


### PR DESCRIPTION
try catch 并不会捕获异步异常，response.json()方法返回的是个Promise。